### PR TITLE
fixed bug with houston causing jk to fail as direction inputs

### DIFF
--- a/src/messages/index.ts
+++ b/src/messages/index.ts
@@ -27,7 +27,7 @@ export const say = async (messages: string | string[] = [], { clear = false, hat
     if (process.stdin.isTTY) process.stdin.setRawMode(true);
     process.stdin.on('keypress', (str, key) => {
         if (process.stdin.isTTY) process.stdin.setRawMode(true);
-        const k = action(key, false);
+        const k = action(key, true);
         if (k === 'abort') {
             done();
             return process.exit(0);


### PR DESCRIPTION
I noticed that if Houston was enabled, a select prompt with raw mode enabled would permanently lock up if any other keypress (not including arrow keys) is done. This fix is only for j and k to function as movement keys and does not fix the underlying bug blocking input. 