### PR TITLE
Adds a task queue loading spinner

### DIFF
--- a/.changeset/breezy-chairs-hope.md
+++ b/.changeset/breezy-chairs-hope.md
@@ -1,0 +1,27 @@
+---
+"@astrojs/cli-kit": minor
+---
+
+Adds a new `tasks` utility that displays a spinner for multiple, sequential tasks.
+
+```js
+import { tasks } from "@astrojs/cli-kit";
+
+const queue = [
+  {
+    pending: "Task 1",
+    start: "Task 1 initializing",
+    end: "Task 1 completed",
+    // async callback will be called and awaited sequentially
+    while: () => someAsyncAction(),
+  },
+  // etc
+];
+
+const labels = {
+  start: "Project initializing...",
+  end: "Project initialized!",
+};
+
+await tasks(labels, queue);
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,13 +3,3 @@ export { default as prompt } from './prompt/prompt.js';
 export * from './spinner/index.js';
 export * from './messages/index.js';
 export * from './project/index.js';
-
-import { tasks } from './spinner/index.js';
-import { randomBetween, sleep } from './utils/index.js';
-
-await tasks({ start: 'Initializing project...', end: 'Project initialized!' }, Array.from({ length: 5 }, (_, i) => ({
-    start: `Task ${i + 1} initializing`,
-    end: `Task ${i + 1} completed`,
-    pending: `Task ${i + 1}`,
-    while: () => sleep(randomBetween(0, 2500))
-})))

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,13 @@ export { default as prompt } from './prompt/prompt.js';
 export * from './spinner/index.js';
 export * from './messages/index.js';
 export * from './project/index.js';
+
+import { tasks } from './spinner/index.js';
+import { randomBetween, sleep } from './utils/index.js';
+
+await tasks({ start: 'Initializing project...', end: 'Project initialized!' }, Array.from({ length: 5 }, (_, i) => ({
+    start: `Task ${i + 1} initializing`,
+    end: `Task ${i + 1} completed`,
+    pending: `Task ${i + 1}`,
+    while: () => sleep(randomBetween(0, 2500))
+})))


### PR DESCRIPTION
A community member is working on a `create-astro` PR that defers all async actions until _after_ the complete user input has been collected. This requires a new UI since the original loading animation was designed for a single blocking task rather than a queue of tasks.

https://github.com/withastro/cli-kit/assets/7118177/cd456cd5-7b7c-4eb7-bb00-ea79701091e2

## Usage

```js
import { tasks } from '@astrojs/cli-kit';

const queue = [
	{
		pending: 'Task 1',
		start: 'Task 1 initializing',
		end: 'Task 1 completed',
		while: () => someAsyncAction()
	},
	// ... and so on
]

const labels = {
	start: 'Initializing project...', 
	end: 'Project initialized!'
};

await tasks(labels, queue)
```
